### PR TITLE
Add correct spelling of energetak to aliases

### DIFF
--- a/cogs/rizky.py
+++ b/cogs/rizky.py
@@ -110,7 +110,7 @@ class Rizky(commands.Cog):
             emoji="🐔",
         )
 
-    @commands.command(name="monster", aliases=["monter", "mosnter", "energitak", ])
+    @commands.command(name="monster", aliases=["monter", "mosnter", "energitak", "energetak", ])
     async def monster(self, ctx):
         await self._send_discounts(
             ctx,


### PR DESCRIPTION
Based on this poll, https://discord.com/channels/1267475337386655745/1353499570285580441/1461137167328874537, "energetak" should be added as alias to "energitak" which already is an alias to !monster. 